### PR TITLE
[Refactor] job 환경 변수 사용 안하도록 세팅 & oci에서 api_key_content 설정

### DIFF
--- a/configmaps/etcd-backup-configmap-oci.yaml
+++ b/configmaps/etcd-backup-configmap-oci.yaml
@@ -9,6 +9,9 @@ data:
   test.sh: |
     #!/bin/sh
 
+    ######creating oci-key
+    echo "{{ .Values.oci.api_key_content }}" >> oci_key.pem
+
     ######oci configure ; automation using expect 
     echo "Configuring OCI-CLI..."
     expect -c "
@@ -30,7 +33,7 @@ data:
     send -- \"n\r\"
 
     expect \"Enter the location of your private key file\"
-    send -- \"{{ .Values.oci.api_key_path }}\r\"
+    send -- \"oci_key.pem\r\"
 
     expect eof
     "

--- a/helm-chart/templates/aws/etcd-backup-job-aws.yaml
+++ b/helm-chart/templates/aws/etcd-backup-job-aws.yaml
@@ -1,12 +1,10 @@
-{{- if eq .Values.cloudProvider "aws" }}
-
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: aws-etcd-backup-job
   namespace: etcd-autobackup
 spec:
-  ttlSecondsAfterFinished: 600
+  ttlSecondsAfterFinished: 120
   template:
     spec:
       nodeSelector:
@@ -35,5 +33,3 @@ spec:
           hostPath:
             path: /etc/kubernetes/pki/etcd/
   backoffLimit: 3
-
-{{- end }}

--- a/helm-chart/templates/ncp/etcd-backup-job-ncp.yaml
+++ b/helm-chart/templates/ncp/etcd-backup-job-ncp.yaml
@@ -1,12 +1,10 @@
-{{- if eq .Values.cloudProvider "ncp" }}
-
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: ncp-etcd-backup-job
   namespace: etcd-autobackup
 spec:
-  ttlSecondsAfterFinished: 600
+  ttlSecondsAfterFinished: 120
   template:
     spec:
       nodeSelector:
@@ -33,7 +31,5 @@ spec:
             name: etcd-backup-configmap-ncp
         - name: cert-hostpath
           hostPath:
-            path: {{ .Values.etcd.cert_path }}
+            path: /etc/kubernetes/pki/etcd/
   backoffLimit: 3
-
-  {{- end }}

--- a/helm-chart/templates/oci/etcd-backup-configmap-oci.yaml
+++ b/helm-chart/templates/oci/etcd-backup-configmap-oci.yaml
@@ -8,6 +8,9 @@ metadata:
 data:
   test.sh: |
     #!/bin/sh
+    ######creating oci-key
+    echo "{{ .Values.oci.api_key_content }}" >> oci_key.pem
+
 
     ######oci configure ; automation using expect 
     echo "Configuring OCI-CLI."
@@ -31,7 +34,7 @@ data:
     send -- \"n\r\"
 
     expect \"Enter the location of your private key file\"
-    send -- \"{{ .Values.oci.api_key_path }}\r\"
+    send -- \"oci_key.pem\r\"
 
     expect eof
     "

--- a/helm-chart/templates/oci/etcd-backup-job-oci.yaml
+++ b/helm-chart/templates/oci/etcd-backup-job-oci.yaml
@@ -1,12 +1,10 @@
-{{- if eq .Values.cloudProvider "oci" }}
-
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: oci-etcd-backup-job
   namespace: etcd-autobackup
 spec:
-  ttlSecondsAfterFinished: 600
+  ttlSecondsAfterFinished: 120
   template:
     spec:
       nodeSelector: 
@@ -35,10 +33,5 @@ spec:
             name: etcd-backup-configmap-oci
         - name: cert-hostpath
           hostPath:
-            path: {{ .Values.etcd.cert_path }}
-        - name: key-hostpath
-          hostPath:
-            path: {{ .Values.oci.api_key_path }}
+            path: /etc/kubernetes/pki/etcd/
   backoffLimit: 3
-
-{{- end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -21,7 +21,7 @@ cloudProvider: oci
 oci:
   user_ocid: 
   tenancy_ocid: 
-  api_key_path:  #This must exist on the master node. Please write the path from the master node.
+  api_key_content:  #Copy and paste the contents of the oci key file
   bucket_region: 
   namespace: 
 

--- a/jobs/etcd-backup-job-aws.yaml
+++ b/jobs/etcd-backup-job-aws.yaml
@@ -1,12 +1,10 @@
-{{- if eq .Values.cloudProvider "aws" }}
-
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: aws-etcd-backup-job
   namespace: etcd-autobackup
 spec:
-  ttlSecondsAfterFinished: 600
+  ttlSecondsAfterFinished: 120
   template:
     spec:
       nodeSelector:
@@ -35,5 +33,3 @@ spec:
           hostPath:
             path: /etc/kubernetes/pki/etcd/
   backoffLimit: 3
-
-{{- end }}

--- a/jobs/etcd-backup-job-ncp.yaml
+++ b/jobs/etcd-backup-job-ncp.yaml
@@ -1,12 +1,10 @@
-{{- if eq .Values.cloudProvider "ncp" }}
-
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: ncp-etcd-backup-job
   namespace: etcd-autobackup
 spec:
-  ttlSecondsAfterFinished: 600
+  ttlSecondsAfterFinished: 120
   template:
     spec:
       nodeSelector:
@@ -33,7 +31,5 @@ spec:
             name: etcd-backup-configmap-ncp
         - name: cert-hostpath
           hostPath:
-            path: {{ .Values.etcd.cert_path }}
+            path: /etc/kubernetes/pki/etcd/
   backoffLimit: 3
-
-  {{- end }}

--- a/jobs/etcd-backup-job-oci.yaml
+++ b/jobs/etcd-backup-job-oci.yaml
@@ -1,12 +1,10 @@
-{{- if eq .Values.cloudProvider "oci" }}
-
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: oci-etcd-backup-job
   namespace: etcd-autobackup
 spec:
-  ttlSecondsAfterFinished: 600
+  ttlSecondsAfterFinished: 120
   template:
     spec:
       nodeSelector: 
@@ -35,10 +33,5 @@ spec:
             name: etcd-backup-configmap-oci
         - name: cert-hostpath
           hostPath:
-            path: {{ .Values.etcd.cert_path }}
-        - name: key-hostpath
-          hostPath:
-            path: {{ .Values.oci.api_key_path }}
+            path: /etc/kubernetes/pki/etcd/
   backoffLimit: 3
-
-  {{- end }}


### PR DESCRIPTION
- job에서 환경변수를 사용하지 않도록 수정
- oci에서 `api_key_path` 대신 `api_key_content`를 사용하도록 수정